### PR TITLE
Enable ComponentPresentations custom metadata sort for GraphQL ApiClient

### DIFF
--- a/net/src/Sdl.Tridion.Api.Client/ContentModel/ContentModel.cs
+++ b/net/src/Sdl.Tridion.Api.Client/ContentModel/ContentModel.cs
@@ -1366,6 +1366,10 @@ namespace Sdl.Tridion.Api.Client.ContentModel
 	/// </summary>
 	public class InputSortParam
 	{
+		public string Key { get; set; }
+
+		public MetadataType KeyType { get; set; }
+
 		/// <summary>
 		/// The sort order type.
 		/// </summary>
@@ -1389,6 +1393,19 @@ namespace Sdl.Tridion.Api.Client.ContentModel
 		Ascending,
 
 		Descending
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum MetadataType
+	{
+		/// <summary>
+		/// A string value
+		/// </summary>
+		STRING,
+
+		DATE,
+
+		FLOAT
 	}
 
 	/// <summary>
@@ -1442,7 +1459,12 @@ namespace Sdl.Tridion.Api.Client.ContentModel
 		/// </summary>
 		TITLE,
 
-		UPDATED_DATE
+		UPDATED_DATE,
+
+		/// <summary>
+		/// CUSTOM_META
+		/// </summary>
+		CUSTOM_META
 	}
 
 	/// <summary>

--- a/net/src/Sdl.Tridion.Api.Client/Queries/ComponentPresentations.graphql
+++ b/net/src/Sdl.Tridion.Api.Client/Queries/ComponentPresentations.graphql
@@ -1,5 +1,5 @@
-﻿query componentPresentations($namespaceId: Int!, $publicationId: Int!, $first: Int, $after: String, $filter: InputComponentPresentationFilter!, $sort: InputSortParam, $contextData: [InputClaimValue!]) {
-	componentPresentations(namespaceId: $namespaceId, publicationId: $publicationId, first: $first, after: $after, filter: $filter, sort: $sort, contextData: $contextData) {
+﻿query componentPresentations($namespaceId: Int!, $publicationId: Int!, $first: Int, $after: String, $filter: InputComponentPresentationFilter!, $inputSortParam: InputSortParam, $contextData: [InputClaimValue!]) {
+	componentPresentations(namespaceId: $namespaceId, publicationId: $publicationId, first: $first, after: $after, filter: $filter, sort: $inputSortParam, contextData: $contextData) {
 		edges {
 			  cursor
 			  node {


### PR DESCRIPTION
Changes:
Added two new properties (Key and KeyType) for InputSortParam
Added new enum MetadataType in ContentModel class
Added new value (CUSTOM_META) for enum SortFieldType

Note: Most likely this functionality needs a hotfix to be installed in the server where sdl tridion resides.