### PR TITLE
Fixed a bug in SearchByCriteria query and added sortBy parameter to enable custom sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ CoverageReports/
 *.iml
 target/
 .idea/
+/net/src/Sdl.Tridion.Api.Client/Sdl.Tridion.Api.Client.sln

--- a/net/src/Sdl.Tridion.Api.Client/ApiClient.cs
+++ b/net/src/Sdl.Tridion.Api.Client/ApiClient.cs
@@ -357,12 +357,12 @@ namespace Sdl.Tridion.Api.Client
         /// <param name="pagination"></param>
         /// <returns></returns>
         /// <exception cref="ApiException"></exception>
-        public FacetedSearchResults SearchByCriteria(InputCriteria inputCriteria, InputResultFilter resultFilter, IPagination pagination)
+        public FacetedSearchResults SearchByCriteria(InputCriteria inputCriteria, InputResultFilter resultFilter, IPagination pagination, InputSortBy sort)
         {
             try
             {
                 var response =
-                    _client.Execute<ContentQuery>(GraphQLRequests.SearchByCriteria(inputCriteria, resultFilter, pagination));
+                    _client.Execute<ContentQuery>(GraphQLRequests.SearchByCriteria(inputCriteria, resultFilter, pagination, sort));
                 return response.TypedResponseData.Search;
             }
             catch (RuntimeBinderException e)

--- a/net/src/Sdl.Tridion.Api.Client/ContentModel/ContentModel.cs
+++ b/net/src/Sdl.Tridion.Api.Client/ContentModel/ContentModel.cs
@@ -3111,7 +3111,7 @@ namespace Sdl.Tridion.Api.Client.ContentModel
 		/// <summary>
 		/// Matching score of the result.
 		/// </summary>
-		public float Score { get; set; }
+		public float? Score { get; set; }
 
 		/// <summary>
 		/// The url of the search result.

--- a/net/src/Sdl.Tridion.Api.Client/GraphQLRequests.cs
+++ b/net/src/Sdl.Tridion.Api.Client/GraphQLRequests.cs
@@ -317,7 +317,7 @@ namespace Sdl.Tridion.Api.Client
                     .Build();
         }
 
-        public static IGraphQLRequest SearchByCriteria(InputCriteria criteria, InputResultFilter resultFilter, IPagination pagination)
+        public static IGraphQLRequest SearchByCriteria(InputCriteria criteria, InputResultFilter resultFilter, IPagination pagination, InputSortBy sort)
         {
             QueryBuilder builder =
                 new QueryBuilder().WithQueryResource("SearchByCriteria", false);
@@ -327,6 +327,7 @@ namespace Sdl.Tridion.Api.Client
                     .WithVariable("criteria", criteria)
                     .WithVariable("inputResultFilter", resultFilter)
                     .WithPagination(pagination)
+                    .WithInputSortBy(sort)
                     .Build();
         }
 

--- a/net/src/Sdl.Tridion.Api.Client/IApiClient.cs
+++ b/net/src/Sdl.Tridion.Api.Client/IApiClient.cs
@@ -368,7 +368,7 @@ namespace Sdl.Tridion.Api.Client
         /// <param name="resultFilter"></param>
         /// <param name="pagination"></param>
         /// <returns></returns>
-        FacetedSearchResults SearchByCriteria(InputCriteria criteria, InputResultFilter resultFilter, IPagination pagination);
+        FacetedSearchResults SearchByCriteria(InputCriteria criteria, InputResultFilter resultFilter, IPagination pagination, InputSortBy sort);
 
         /// <summary>
         /// Faceted Search by criteria

--- a/net/src/Sdl.Tridion.Api.Client/Queries/SearchByCriteria.graphql
+++ b/net/src/Sdl.Tridion.Api.Client/Queries/SearchByCriteria.graphql
@@ -1,5 +1,5 @@
-﻿query search($first: Int, $after: String, $criteria: InputCriteria, $inputResultFilter: InputResultFilter) {          
-    search(InputCriteria: $criteria, resultFilter: $inputResultFilter ) {
+﻿query search($first: Int, $after: String, $criteria: InputCriteria, $inputResultFilter: InputResultFilter, $inputSortBy: InputSortBy) {          
+    search(criteria: $criteria, resultFilter: $inputResultFilter, sortBy: $inputSortBy) {
 		 results(first: $first, after: $after) {
             hits
               edges {

--- a/net/src/Sdl.Tridion.Api.Client/QueryBuilder.cs
+++ b/net/src/Sdl.Tridion.Api.Client/QueryBuilder.cs
@@ -89,6 +89,8 @@ namespace Sdl.Tridion.Api.Client
 
         public QueryBuilder WithInputSortParam(InputSortParam sort) => WithVariable("inputSortParam", sort);
 
+        public QueryBuilder WithInputSortBy(InputSortBy sort) => WithVariable("InputSortBy", sort);
+
         public QueryBuilder WithInputComponentPresentationFilter(InputComponentPresentationFilter filter)
             => WithVariable("filter", filter);
 


### PR DESCRIPTION
Added missing sortBy parameter for SearchByCriteria query and fixed parameter name criteria

Made required changes to IApiClient, ApiClient, GraphQLRequests and QueryBuilder to use the new sortBy parameter